### PR TITLE
Fixed textfield width on select bug

### DIFF
--- a/src/styles/generic/_layout.scss
+++ b/src/styles/generic/_layout.scss
@@ -210,6 +210,7 @@ input, textarea {
 .description {
   color: #000;
   resize: none;
+  width: 600px;
   font-size: 16px;
 }
 


### PR DESCRIPTION
Fixed only a minor bug. Text field after selection remained small. Changed width, also works for mobile. 